### PR TITLE
close all fds with closefrom()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CFLAGS = -std=c99 -O2
 all: keept keept.1
 
 keept: $(KEEPT_OBJS)
-	$(CC) -o $@ $(KEEPT_OBJS) -lutil
+	$(CC) -o $@ $(KEEPT_OBJS) -lutil -lbsd
 
 VS = keept 1.0
 VD = 2019-01-14

--- a/keept.c
+++ b/keept.c
@@ -20,6 +20,7 @@
 #include "more-warnings.h"
 
 #include <unistd.h>
+#include <bsd/unistd.h>  // closefrom()
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1005,7 +1006,7 @@ int main(int argc, const char * argv[])
 	else G.tty = true;
     }
 
-    for (int i = 3; i < 10; i++) close(i);
+    closefrom(3);
 
     int s = connect_usock(sockname OPTARG_ABSTRACT_SOCKET);
     if (s >= 0) {


### PR DESCRIPTION
use `closefrom()` to close many FDs. i have not lookup how much portable is it, but some source says it's in all unices except linux, however I've it on my linux.